### PR TITLE
ci: add test workflow for pnpm suites

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,30 @@
+---
+name: test.ci
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.13.0
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run type check
+        run: pnpm check
+      - name: Run unit tests
+        run: pnpm test:unit -- --run
+      - name: Run E2E tests
+        run: pnpm test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-	webServer: { command: 'npm run build && npm run preview', port: 4173 },
-	testDir: 'e2e'
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+  },
+  webServer: {
+    command: 'pnpm dev --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: true,
+  },
+  testDir: 'e2e',
 });


### PR DESCRIPTION
## Summary
- add a new GitHub Actions workflow that installs dependencies and runs `pnpm check`, `pnpm test:unit -- --run`, and `pnpm test:e2e`
- update Playwright's local web server config so the E2E suite runs against the dev server and passes consistently
- verified locally with `pnpm check`, `pnpm test:unit -- --run`, and `pnpm test:e2e`