### PR TITLE
ci: limit autofix workflow to article changes

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,6 +1,10 @@
 ---
 name: autofix.ci
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths:
+      - 'src/lib/posts/**/*.md'
+  workflow_dispatch:
 jobs:
   textlint:
     runs-on: ubuntu-latest
@@ -26,7 +30,7 @@ jobs:
             ${{ runner.os }}-node-
       - name: Run textlint
         # textlint の終了コードを強制0にする
-        run: npx textlint --fix urara/**/*.md | true
+        run: npx textlint --fix src/lib/posts/**/*.md | true
         shell: bash {0}
       - name: Autofix
         uses: autofix-ci/action@635ffb0c9798bd160680f18fd73371e355b85f27


### PR DESCRIPTION
## Summary
- update the existing autofix workflow to run automatically only when markdown files under `src/lib/posts/` change
- align the textlint target path with the current article directory structure
- keep `workflow_dispatch` available for manual runs when needed