### PR TITLE
fix(wrangler): Change not found handling to none in wrangler

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,10 +7,10 @@
   "assets": {
     "binding": "ASSETS",
     "directory": ".svelte-kit/cloudflare",
-    // 404 ページを提供するための設定
-    "not_found_handling": "404-page"
+    // 静的ファイルが見つからない場合の挙動を指定
+    "not_found_handling": "none"
   },
   // workers.dev ドメイン
-  "workers_dev": false,
+  "workers_dev": true,
   "preview_urls": true
 }


### PR DESCRIPTION
1. Assets チェック: 指定されたパスに静的ファイル（.js, .css, .png など）があるか探す。
2. 404 ハンドリング: ファイルがない場合、not_found_handling の設定に従う。
404-page の場合: ここで 404.html を返して終了。
none の場合: Assets 層では何もせず、リクエストを Worker (_worker.js) へパスする。
3. Worker 実行: SvelteKit 本体が起動し、URL に応じたページを生成する。

という順なので 404-page だと SvelteKit が起動しない?