### PR TITLE
chore(renovate): lockFileMaintenanceを無効化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
   "platformAutomerge": true,
   "prHourlyLimit": 1,
   "minimumReleaseAge": "3 days",
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
     {
       "groupName": "svelte",


### PR DESCRIPTION
Renovateによる定期的なロックファイルのメンテナンスPRの生成を無効化します。