### PR TITLE
feat: RSSフィード (rss.xml) の生成と配信に対応 (#720)

### DIFF
--- a/e2e/blog.test.ts
+++ b/e2e/blog.test.ts
@@ -37,3 +37,15 @@ test('missing article returns a 404 page', async ({ page }) => {
   await page.screenshot({ path: 'e2e/screenshots/404-page.png' });
   await expect(page.getByRole('heading', { level: 1 })).toContainText('404');
 });
+
+test('rss feed loads successfully', async ({ request }) => {
+  const response = await request.get('/rss.xml');
+  
+  expect(response.ok()).toBeTruthy();
+  expect(response.headers()['content-type']).toContain('application/xml');
+  
+  const text = await response.text();
+  expect(text).toContain('<?xml version="1.0" encoding="UTF-8" ?>');
+  expect(text).toContain('<title>blog hobby</title>');
+  expect(text).toContain('<rss version="2.0"');
+});

--- a/e2e/blog.test.ts
+++ b/e2e/blog.test.ts
@@ -8,6 +8,11 @@ test('home, article, and tag pages are connected', async ({ page }) => {
     'blog hobby'
   );
 
+  await expect(page.getByRole('link', { name: 'RSS' })).toHaveAttribute(
+    'href',
+    '/rss.xml'
+  );
+
   const firstArticleLink = page.getByRole('link', {
     name: '関西万博2025感想',
   });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 
 <svelte:head>
 	<link rel="icon" href={favicon} />
+	<link rel="alternate" type="application/rss+xml" title="blog hobby" href="/rss.xml" />
 </svelte:head>
 
 <div class="app-shell">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,8 +11,12 @@
 
 <div class="app-shell">
 	<header class="site-header">
-		<a class="site-title" href="/">blog hobby</a>
-		<p class="site-description">趣味のブログ</p>
+		<div class="site-brand">
+			<a class="site-title" href="/">blog hobby</a>
+			<p class="site-description">趣味のブログ</p>
+		</div>
+
+		<a class="rss-link" href="/rss.xml">RSS</a>
 	</header>
 
 	<main class="site-main">
@@ -38,9 +42,17 @@
 	}
 
 	.site-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
 		padding: 2rem 1.5rem 1rem;
 		max-width: 72rem;
 		margin: 0 auto;
+	}
+
+	.site-brand {
+		min-width: 0;
 	}
 
 	.site-title {
@@ -54,9 +66,38 @@
 		color: #475569;
 	}
 
+	.rss-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		min-height: 2.5rem;
+		padding: 0.5rem 1rem;
+		border-radius: 9999px;
+		background: #0f172a;
+		color: #fff;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	.rss-link:hover {
+		background: #1e293b;
+	}
+
+	.rss-link:focus-visible {
+		outline: 2px solid #f59e0b;
+		outline-offset: 2px;
+	}
+
 	.site-main {
 		max-width: 72rem;
 		margin: 0 auto;
 		padding: 0 1.5rem 4rem;
+	}
+
+	@media (max-width: 640px) {
+		.site-header {
+			flex-direction: column;
+		}
 	}
 </style>

--- a/src/routes/layout.svelte.spec.ts
+++ b/src/routes/layout.svelte.spec.ts
@@ -1,0 +1,20 @@
+import { createRawSnippet } from 'svelte';
+import { page } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import Layout from './+layout.svelte';
+
+describe('/+layout.svelte', () => {
+	it('renders an RSS link in the site header', async () => {
+		render(Layout, {
+			children: createRawSnippet(() => ({
+				render: () => '<div>child content</div>'
+			}))
+		});
+
+		await expect.element(page.getByRole('link', { name: 'RSS' })).toHaveAttribute(
+			'href',
+			'/rss.xml'
+		);
+	});
+});

--- a/src/routes/rss.xml/+server.ts
+++ b/src/routes/rss.xml/+server.ts
@@ -1,0 +1,35 @@
+import type { RequestHandler } from './$types';
+import { getAllPosts } from '$lib/posts';
+
+export const GET: RequestHandler = async ({ url }) => {
+  const posts = await getAllPosts();
+
+  const headers = {
+    'Cache-Control': 'max-age=0, s-maxage=3600',
+    'Content-Type': 'application/xml',
+  };
+
+  const xml = `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+	<channel>
+		<title>blog hobby</title>
+		<description>趣味のブログ</description>
+		<link>${url.origin}</link>
+		<atom:link href="${url.origin}/rss.xml" rel="self" type="application/rss+xml"/>
+		${posts
+      .map(
+        (post) => `
+		<item>
+			<title>${post.title}</title>
+			<description><![CDATA[${post.excerpt}]]></description>
+			<link>${url.origin}/articles/${post.slug}</link>
+			<guid isPermaLink="true">${url.origin}/articles/${post.slug}</guid>
+			<pubDate>${new Date(post.created).toUTCString()}</pubDate>
+		</item>`
+      )
+      .join('')}
+	</channel>
+</rss>`;
+
+  return new Response(xml.trim(), { headers });
+};


### PR DESCRIPTION
Resolves #720

## 対応内容
- `src/routes/rss.xml/+server.ts` にブログ記事からRSS 2.0フィードを動的に生成するエンドポイントを実装しました。
- `src/routes/+layout.svelte` の `<head>` に `link[rel="alternate"]` を追加し、RSSリーダーがサイトURLからフィードを自動発見できるようにしました。
- エンドポイントから正しくXMLが返却されることを検証するE2Eテストを追加しました。