### PR TITLE
feat: Google Analytics 追加 (#669)

### DIFF
--- a/e2e/analytics.test.ts
+++ b/e2e/analytics.test.ts
@@ -1,33 +1,71 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
-test('Google Analytics tracks page views on client-side routing', async ({
+test('Google Analytics tracks page views on initial load and client-side routing', async ({
   page,
 }) => {
-  // 実際のアナリティクスへのリクエストをブロック（テストデータが送信されるのを防ぐ）
+  await page.route('**/gtag/js?id=*', async (route) => {
+    await route.fulfill({
+      contentType: 'application/javascript',
+      body: `
+window.gtag = function gtag() {
+  const args = Array.from(arguments);
+  if (args[0] !== 'config') {
+    return;
+  }
+
+  const options = args[2];
+  const pagePath =
+    options && typeof options === 'object' && 'page_path' in options && options.page_path
+      ? String(options.page_path)
+      : location.pathname;
+  const url = new URL('https://www.google-analytics.com/g/collect');
+  url.searchParams.set('en', 'page_view');
+  url.searchParams.set('dp', pagePath);
+  url.searchParams.set('tid', String(args[1] ?? ''));
+  fetch(url.toString());
+};
+
+for (const entry of (window.dataLayer || []).slice()) {
+  window.gtag.apply(null, Array.from(entry));
+}
+`,
+    });
+  });
+
   await page.route('**/*google-analytics.com/g/collect*', (route) =>
     route.abort()
   );
 
-  // 1. Playwrightでアプリケーションの画面を開く。
+  const initialCollectPromise = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return (
+      url.pathname === '/g/collect' &&
+      url.searchParams.get('dp') === '/' &&
+      url.searchParams.get('en') === 'page_view'
+    );
+  });
+
   await page.goto('/');
-
-  // 初期ロードが完了するまで待機（初期ロード時のGAリクエストと区別するため）
   await expect(page.getByRole('heading', { level: 1 })).toContainText(
-    'blog hobby'
+    'matukoto blog'
   );
 
-  // 2. バックグラウンドで google-analytics.com/g/collect を含むURLへのリクエストの待機（監視）を開始する。
-  const gaRequestPromise = page.waitForRequest((request) =>
-    request.url().includes('google-analytics.com/g/collect')
-  );
+  const initialCollect = await initialCollectPromise;
+  const initialUrl = new URL(initialCollect.url());
+  expect(initialUrl.searchParams.get('tid')).toBe('G-TEST123456');
 
-  // 3. 画面内のリンクをクリックし、SvelteKitのクライアントサイドルーティング（ページ遷移）を発生させる。
+  const navigationCollectPromise = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return (
+      url.pathname === '/g/collect' &&
+      url.searchParams.get('dp') === '/articles/expo' &&
+      url.searchParams.get('en') === 'page_view'
+    );
+  });
+
   await page.getByRole('link', { name: '関西万博2025感想' }).click();
 
-  // 4. Playwrightが捕獲したリクエストのURLを解析し、パラメータに正しいイベント名（en=page_view）や、遷移先のパス（ep.page_path）が含まれているかをアサーション（検証）する。
-  const gaRequest = await gaRequestPromise;
-  const url = new URL(gaRequest.url());
-
-  expect(url.searchParams.get('en')).toBe('page_view');
-  expect(url.searchParams.get('dp')).toBe('/articles/expo');
+  const navigationCollect = await navigationCollectPromise;
+  const navigationUrl = new URL(navigationCollect.url());
+  expect(navigationUrl.searchParams.get('tid')).toBe('G-TEST123456');
 });

--- a/e2e/analytics.test.ts
+++ b/e2e/analytics.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test('Google Analytics tracks page views on client-side routing', async ({
+  page,
+}) => {
+  // 実際のアナリティクスへのリクエストをブロック（テストデータが送信されるのを防ぐ）
+  await page.route('**/*google-analytics.com/g/collect*', (route) =>
+    route.abort()
+  );
+
+  // 1. Playwrightでアプリケーションの画面を開く。
+  await page.goto('/');
+
+  // 初期ロードが完了するまで待機（初期ロード時のGAリクエストと区別するため）
+  await expect(page.getByRole('heading', { level: 1 })).toContainText(
+    'blog hobby'
+  );
+
+  // 2. バックグラウンドで google-analytics.com/g/collect を含むURLへのリクエストの待機（監視）を開始する。
+  const gaRequestPromise = page.waitForRequest((request) =>
+    request.url().includes('google-analytics.com/g/collect')
+  );
+
+  // 3. 画面内のリンクをクリックし、SvelteKitのクライアントサイドルーティング（ページ遷移）を発生させる。
+  await page.getByRole('link', { name: '関西万博2025感想' }).click();
+
+  // 4. Playwrightが捕獲したリクエストのURLを解析し、パラメータに正しいイベント名（en=page_view）や、遷移先のパス（ep.page_path）が含まれているかをアサーション（検証）する。
+  const gaRequest = await gaRequestPromise;
+  const url = new URL(gaRequest.url());
+
+  expect(url.searchParams.get('en')).toBe('page_view');
+  expect(url.searchParams.get('dp')).toBe('/articles/expo');
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     command: 'pnpm dev --host 127.0.0.1 --port 4173',
     url: 'http://127.0.0.1:4173',
     reuseExistingServer: true,
+    env: {
+      PUBLIC_GA_ID: 'G-TEST123456',
+    },
   },
   testDir: 'e2e',
 });

--- a/src/lib/GoogleAnalytics.svelte
+++ b/src/lib/GoogleAnalytics.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { afterNavigate } from '$app/navigation';
-  import { env } from '$env/dynamic/public';
 
-  const gaId = env.PUBLIC_GA_ID;
+  type Props = {
+    gaId?: string;
+  };
+
+  let { gaId }: Props = $props();
 
   afterNavigate(({ to }) => {
     if (typeof window !== 'undefined' && 'gtag' in window && to?.url && gaId) {
@@ -17,6 +20,7 @@
 <svelte:head>
   {#if gaId}
     <script
+      data-ga-id={gaId}
       async
       src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
     ></script>
@@ -27,7 +31,10 @@
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-      gtag('config', '{gaId}');
+      const script = document.currentScript;
+      if (script instanceof HTMLScriptElement && script.dataset.gaId) {
+        gtag('config', script.dataset.gaId);
+      }
     </script>
   {/if}
 </svelte:head>

--- a/src/lib/GoogleAnalytics.svelte
+++ b/src/lib/GoogleAnalytics.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { afterNavigate } from '$app/navigation';
+  import { env } from '$env/dynamic/public';
+
+  const gaId = env.PUBLIC_GA_ID;
+
+  afterNavigate(({ to }) => {
+    if (typeof window !== 'undefined' && 'gtag' in window && to?.url && gaId) {
+      // @ts-expect-error gtag is injected by Google Analytics
+      window.gtag('config', gaId, {
+        page_path: to.url.pathname,
+      });
+    }
+  });
+</script>
+
+<svelte:head>
+  {#if gaId}
+    <script
+      async
+      src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        // biome-ignore lint/complexity/noArguments: Google Analytics snippet needs arguments
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '{gaId}');
+    </script>
+  {/if}
+</svelte:head>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import { env } from '$env/dynamic/public';
+
+export function load() {
+  return {
+    gaId: env.PUBLIC_GA_ID,
+  };
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { LayoutData } from './$types';
   import GoogleAnalytics from '$lib/GoogleAnalytics.svelte';
-  let { children } = $props();
+
+  let {
+    children,
+    data,
+  }: {
+    children: Snippet;
+    data?: LayoutData;
+  } = $props();
 </script>
 
-<GoogleAnalytics/>
+<GoogleAnalytics gaId={data?.gaId}/>
 
 <svelte:head>
   <link rel="icon" href="/assets/favicon.ico">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import GoogleAnalytics from '$lib/GoogleAnalytics.svelte';
   let { children } = $props();
 </script>
+
+<GoogleAnalytics/>
 
 <svelte:head>
   <link rel="icon" href="/assets/favicon.ico">

--- a/src/routes/articles/[slug]/page.svelte.spec.ts
+++ b/src/routes/articles/[slug]/page.svelte.spec.ts
@@ -8,6 +8,7 @@ describe('/articles/[slug]/+page.svelte', () => {
   it('renders the article body and tag links', async () => {
     render(Page, {
       data: {
+        gaId: '',
         post: {
           slug: 'first',
           title: 'SvelteKit でブログを作ってみた',

--- a/src/routes/page.svelte.spec.ts
+++ b/src/routes/page.svelte.spec.ts
@@ -7,6 +7,7 @@ describe('/+page.svelte', () => {
   it('renders the article list and tag links', async () => {
     render(Page, {
       data: {
+        gaId: '',
         posts: [
           {
             slug: 'first',

--- a/src/routes/tags/[tag]/page.svelte.spec.ts
+++ b/src/routes/tags/[tag]/page.svelte.spec.ts
@@ -8,6 +8,7 @@ describe('/tags/[tag]/+page.svelte', () => {
   it('renders tagged posts', async () => {
     render(Page, {
       data: {
+        gaId: '',
         tag: { name: 'tech', slug: 'tech', count: 2 },
         posts: [
           {


### PR DESCRIPTION
Resolves #669

## 対応内容
- `src/lib/GoogleAnalytics.svelte` コンポーネントを作成しました。
- `src/routes/+layout.svelte` にコンポーネントを読み込みました。
- 環境変数 `PUBLIC_GA_ID` が設定されている場合のみトラッキングコードを出力するようにしました。
- クライアントサイドのルーティング（SPA遷移）時に `afterNavigate` を使用して `page_view` イベントを正しく送信する処理を追加しました。