### PR TITLE
Fix format

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   // VCS（バージョン管理システム）設定
   "vcs": {
     "enabled": true,
@@ -21,6 +21,11 @@
     "formatter": {
       "enabled": true,
       "indentScriptAndStyle": true
+    }
+  },
+  "css": {
+    "parser": {
+      "cssModules": true
     }
   },
   // JavaScriptの言語設定

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gen": "wrangler types"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.3.11",
     "@fontsource/noto-sans-jp": "5.2.9",
     "@playwright/test": "1.59.1",
     "@resvg/resvg-js": "2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^18.0.0
         version: 18.0.0
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.3.11
+        version: 2.3.11
       '@fontsource/noto-sans-jp':
         specifier: 5.2.9
         version: 5.2.9
@@ -77,6 +80,63 @@ importers:
         version: 4.83.0
 
 packages:
+
+  '@biomejs/biome@2.3.11':
+    resolution: {integrity: sha512-/zt+6qazBWguPG6+eWmiELqO+9jRsMZ/DBU3lfuU2ngtIQYzymocHhKiZRyrbra4aCOoyTg/BmY+6WH5mv9xmQ==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.3.11':
+    resolution: {integrity: sha512-/uXXkBcPKVQY7rc9Ys2CrlirBJYbpESEDme7RKiBD6MmqR2w3j0+ZZXRIL2xiaNPsIMMNhP1YnA+jRRxoOAFrA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.3.11':
+    resolution: {integrity: sha512-fh7nnvbweDPm2xEmFjfmq7zSUiox88plgdHF9OIW4i99WnXrAC3o2P3ag9judoUMv8FCSUnlwJCM1B64nO5Fbg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.3.11':
+    resolution: {integrity: sha512-XPSQ+XIPZMLaZ6zveQdwNjbX+QdROEd1zPgMwD47zvHV+tCGB88VH+aynyGxAHdzL+Tm/+DtKST5SECs4iwCLg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.3.11':
+    resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.3.11':
+    resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.3.11':
+    resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.3.11':
+    resolution: {integrity: sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.3.11':
+    resolution: {integrity: sha512-43VrG813EW+b5+YbDbz31uUsheX+qFKCpXeY9kfdAx+ww3naKxeVkTD9zLIWxUPfJquANMHrmW3wbe/037G0Qg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -1411,6 +1471,41 @@ packages:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
+
+  '@biomejs/biome@2.3.11':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.3.11
+      '@biomejs/cli-darwin-x64': 2.3.11
+      '@biomejs/cli-linux-arm64': 2.3.11
+      '@biomejs/cli-linux-arm64-musl': 2.3.11
+      '@biomejs/cli-linux-x64': 2.3.11
+      '@biomejs/cli-linux-x64-musl': 2.3.11
+      '@biomejs/cli-win32-arm64': 2.3.11
+      '@biomejs/cli-win32-x64': 2.3.11
+
+  '@biomejs/cli-darwin-arm64@2.3.11':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.3.11':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.3.11':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.3.11':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.3.11':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.3.11':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.3.11':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.3.11':
+    optional: true
 
   '@blazediff/core@1.9.1': {}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
   } = $props();
 </script>
 
-<GoogleAnalytics gaId={data?.gaId}/>
+<GoogleAnalytics gaId={data?.gaId} />
 
 <svelte:head>
   <link rel="icon" href="/assets/favicon.ico">
@@ -43,7 +43,7 @@
           title="GitHub"
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d={siGithub.path} fill="currentColor"/>
+            <path d={siGithub.path} fill="currentColor" />
           </svg>
         </a>
         <a
@@ -55,7 +55,7 @@
           title="BlueSky"
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d={siBluesky.path} fill="currentColor"/>
+            <path d={siBluesky.path} fill="currentColor" />
           </svg>
         </a>
       </nav>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,7 +31,7 @@
             ></a>
 
             {#if post.image}
-              <img class="post-image" src={post.image} alt="" />
+              <img class="post-image" src={post.image} alt="">
             {/if}
 
             <div class="post-body">
@@ -41,10 +41,8 @@
 
               {#if post.tags.length > 0}
                 <ul class="tag-list" aria-label={`${post.title} のタグ`}>
-              {#each post.tags as tag (tag.slug)}
-                    <li>
-                      <a href={`/tags/${tag.slug}`}>{tag.name}</a>
-                    </li>
+                  {#each post.tags as tag (tag.slug)}
+                    <li><a href={`/tags/${tag.slug}`}>{tag.name}</a></li>
                   {/each}
                 </ul>
               {/if}
@@ -63,12 +61,12 @@
     {:else}
       <ul class="all-tags">
         {#each data.tags as tag (tag.slug)}
-					<li>
-						<a href={`/tags/${tag.slug}`}>{tag.name}</a>
-						<span>{tag.count}</span>
-					</li>
-				{/each}
-			</ul>
+          <li>
+            <a href={`/tags/${tag.slug}`}>{tag.name}</a>
+            <span>{tag.count}</span>
+          </li>
+        {/each}
+      </ul>
     {/if}
   </aside>
 </div>

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -106,9 +106,7 @@
 </svelte:head>
 
 <article class="article">
-  <p class="back-link">
-    <a href="/">← 記事一覧へ戻る</a>
-  </p>
+  <p class="back-link"><a href="/">← 記事一覧へ戻る</a></p>
 
   <header class="article-header">
     <p class="article-date">{data.post.created}</p>
@@ -116,12 +114,10 @@
 
     {#if data.post.tags.length > 0}
       <ul class="tag-list" aria-label={`${data.post.title} のタグ`}>
-				{#each data.post.tags as tag}
-					<li>
-						<a href={`/tags/${tag.slug}`}>{tag.name}</a>
-					</li>
-				{/each}
-			</ul>
+        {#each data.post.tags as tag}
+          <li><a href={`/tags/${tag.slug}`}>{tag.name}</a></li>
+        {/each}
+      </ul>
     {/if}
   </header>
 

--- a/src/routes/tags/[tag]/+page.svelte
+++ b/src/routes/tags/[tag]/+page.svelte
@@ -9,9 +9,7 @@
 </svelte:head>
 
 <section class="tag-page">
-  <p class="back-link">
-    <a href="/">← 記事一覧へ戻る</a>
-  </p>
+  <p class="back-link"><a href="/">← 記事一覧へ戻る</a></p>
 
   <header>
     <h1>{data.tag.name}</h1>
@@ -19,20 +17,20 @@
   </header>
 
   <div class="posts">
-		{#each data.posts as post (post.slug)}
-			<article class="post-card">
-				<a
-					class="post-link"
-					href={`/articles/${post.slug}`}
-					aria-label={post.title}
-				></a>
+    {#each data.posts as post (post.slug)}
+      <article class="post-card">
+        <a
+          class="post-link"
+          href={`/articles/${post.slug}`}
+          aria-label={post.title}
+        ></a>
 
-				<p class="post-date">{post.created}</p>
-				<h2>{post.title}</h2>
-				<p class="post-excerpt">{post.excerpt}</p>
-			</article>
-		{/each}
-	</div>
+        <p class="post-date">{post.created}</p>
+        <h2>{post.title}</h2>
+        <p class="post-excerpt">{post.excerpt}</p>
+      </article>
+    {/each}
+  </div>
 </section>
 
 <style>


### PR DESCRIPTION
This pull request updates the Biome dependency to version 2.3.11 and improves configuration for CSS modules support. It also includes minor code style cleanups in Svelte files to make the markup more concise.

Dependency and configuration updates:

* Updated the Biome dependency to version 2.3.11 in `package.json`, `pnpm-lock.yaml`, and updated the `$schema` reference in `biome.jsonc`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15-R17) [[3]](diffhunk://#diff-955d6dd0b9089fa951f33ccabbab4597fe019091b7bb81e166df2b34dea4a906L2-R2)
* Added Biome CLI platform-specific optional dependencies in `pnpm-lock.yaml` for better cross-platform support. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR84-R140) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1475-R1509)
* Enabled CSS modules support in Biome by updating the `css.parser.cssModules` option in `biome.jsonc`.

Code style improvements:

* Simplified markup in several Svelte files by removing unnecessary whitespace and flattening single-line elements in `src/routes/+page.svelte`, `src/routes/articles/[slug]/+page.svelte`, and `src/routes/tags/[tag]/+page.svelte`. [[1]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL34-R34) [[2]](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL45-R45) [src/routes/articles/[slug]/+page.svelteL109-R109](diffhunk://#diff-6f05ffa15f2c7468ca8e4488483a621d8367e0166cd76f432126598b1233bb1fL109-R109), [src/routes/articles/[slug]/+page.svelteL120-R118](diffhunk://#diff-6f05ffa15f2c7468ca8e4488483a621d8367e0166cd76f432126598b1233bb1fL120-R118), [src/routes/tags/[tag]/+page.svelteL12-R12](diffhunk://#diff-f7c67c9b7395846d1889d42a2defb828210888790bd5f4ecbbd575d11bbd3b91L12-R12))