### PR TITLE
feat(article): 記事内の見出し(h1-h5)に装飾スタイルを追加

### DIFF
--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -211,9 +211,43 @@
     margin-bottom: 1.5rem;
   }
 
+  .article-content :global(h1),
   .article-content :global(h2),
-  .article-content :global(h3) {
+  .article-content :global(h3),
+  .article-content :global(h4),
+  .article-content :global(h5) {
     margin-top: 2rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.35rem;
+    line-height: 1.3;
+    border-bottom-width: 0.14rem;
+    border-bottom-style: solid;
+    border-bottom-color: transparent;
+  }
+
+  .article-content :global(h1) {
+    border-bottom-color: #1d4ed8;
+  }
+
+  .article-content :global(h2) {
+    border-bottom-style: double;
+    border-bottom-color: #0f766e;
+  }
+
+  .article-content :global(h3) {
+    border-bottom-style: dashed;
+    border-bottom-color: #d97706;
+  }
+
+  .article-content :global(h4) {
+    border-bottom-style: dotted;
+    border-bottom-color: #7c3aed;
+  }
+
+  .article-content :global(h5) {
+    border-bottom-style: groove;
+    border-bottom-width: 0.2rem;
+    border-bottom-color: #db2777;
   }
 
   .article-content :global(p),

--- a/src/routes/articles/[slug]/page.svelte.spec.ts
+++ b/src/routes/articles/[slug]/page.svelte.spec.ts
@@ -33,17 +33,59 @@ describe('/articles/[slug]/+page.svelte', () => {
             { name: 'svelte', slug: 'svelte' },
             { name: 'cloudflare', slug: 'cloudflare' },
           ],
-          content: '<h2>感想</h2><p>本文</p>',
+          content: `
+            <h1>導入</h1>
+            <h2>感想</h2>
+            <h3>補足</h3>
+            <h4>詳細</h4>
+            <h5>メモ</h5>
+            <p>本文</p>
+          `,
         }),
       }),
     });
 
     await expect
-      .element(page.getByRole('heading', { level: 1 }))
+      .element(
+        page.getByRole('heading', {
+          level: 1,
+          name: 'SvelteKit でブログを作ってみた',
+        })
+      )
       .toHaveTextContent('SvelteKit でブログを作ってみた');
     await expect
       .element(page.getByRole('heading', { level: 2 }))
       .toHaveTextContent('感想');
+    expect(
+      getComputedStyle(
+        document.querySelector('.article-content h1') as HTMLElement
+      ).borderBottomStyle
+    ).toBe('solid');
+    expect(
+      getComputedStyle(
+        document.querySelector('.article-content h2') as HTMLElement
+      ).borderBottomStyle
+    ).toBe('double');
+    expect(
+      getComputedStyle(
+        document.querySelector('.article-content h3') as HTMLElement
+      ).borderBottomStyle
+    ).toBe('dashed');
+    expect(
+      getComputedStyle(
+        document.querySelector('.article-content h4') as HTMLElement
+      ).borderBottomStyle
+    ).toBe('dotted');
+    expect(
+      getComputedStyle(
+        document.querySelector('.article-content h5') as HTMLElement
+      ).borderBottomStyle
+    ).toBe('groove');
+    expect(
+      getComputedStyle(
+        document.querySelector('header.article-header h1') as HTMLElement
+      ).borderBottomStyle
+    ).toBe('none');
     await expect
       .element(page.getByRole('link', { name: 'svelte' }))
       .toHaveAttribute('href', '/tags/svelte');


### PR DESCRIPTION

記事コンテンツ内の見出しレベル（h1〜h5）に、個別のボーダースタイルと色を適用しました。
また、テストで各見出しのスタイルが正しく適用されているかを確認する処理を追加しました。