### PR TITLE
feat(share): シェア時のタイトル構成とモバイル動作を調整

### DIFF
--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -6,14 +6,17 @@
   type ShareState = 'idle' | 'success' | 'error';
 
   let shareState = $state<ShareState>('idle');
-  const BLOG_NAME = 'matukoto blog';
 
   function getShareUrl() {
     return new URL(`/articles/${data.post.slug}`, data.origin).toString();
   }
 
-  function getShareText(shareUrl: string) {
-    return `${data.post.title} | ${BLOG_NAME}\n${shareUrl}`;
+  function getShareTitle() {
+    return `${data.post.title}`;
+  }
+
+  function getDesktopClipboardText(shareUrl: string) {
+    return `${getShareTitle()}\n${shareUrl}`;
   }
 
   function isDesktopLike() {
@@ -55,15 +58,15 @@
   async function handleShare() {
     resetShareState();
     const shareUrl = getShareUrl();
-    const shareText = getShareText(shareUrl);
-    const shareTitle = `${data.post.title} | ${BLOG_NAME}`;
+    const shareTitle = getShareTitle();
     if (isDesktopLike()) {
-      await copyShareText(shareText);
+      await copyShareText(getDesktopClipboardText(shareUrl));
       return;
     }
 
     const shareData = {
       title: shareTitle,
+      text: getShareTitle(),
       url: shareUrl,
     };
 
@@ -79,7 +82,7 @@
       }
     }
 
-    await copyShareText(shareText);
+    await copyShareText(getShareUrl());
   }
 </script>
 

--- a/src/routes/articles/[slug]/page.svelte.spec.ts
+++ b/src/routes/articles/[slug]/page.svelte.spec.ts
@@ -147,7 +147,7 @@ describe('/articles/[slug]/+page.svelte', () => {
     await page.getByRole('button', { name: 'share' }).click();
 
     expect(writeText).toHaveBeenCalledWith(
-      'SvelteKit でブログを作ってみた | matukoto blog\nhttps://example.com/articles/first'
+      'SvelteKit でブログを作ってみた\nhttps://example.com/articles/first'
     );
     expect(share).not.toHaveBeenCalled();
     await expect
@@ -156,7 +156,7 @@ describe('/articles/[slug]/+page.svelte', () => {
     expect(document.querySelector('.share-status')).toBeNull();
   });
 
-  it('sends only title and url on mobile share', async () => {
+  it('sends title, text and url to the mobile share target', async () => {
     const share = vi.fn().mockResolvedValue(undefined);
 
     mockMatchMedia(false);
@@ -188,9 +188,39 @@ describe('/articles/[slug]/+page.svelte', () => {
 
     expect(share).toHaveBeenCalledTimes(1);
     expect(share).toHaveBeenCalledWith({
-      title: 'SvelteKit でブログを作ってみた | matukoto blog',
+      title: 'SvelteKit でブログを作ってみた',
+      text: 'SvelteKit でブログを作ってみた',
       url: 'https://example.com/articles/first',
     });
+  });
+
+  it('copies only the url on mobile clipboard fallback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    mockMatchMedia(false);
+    Reflect.deleteProperty(navigator, 'share');
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(Page, {
+      data: makeArticlePageData({
+        post: makePost({
+          tags: [],
+          content: '<p>本文</p>',
+        }),
+      }),
+    });
+
+    await page.getByRole('button', { name: 'share' }).click();
+
+    expect(writeText).toHaveBeenCalledWith(
+      'https://example.com/articles/first'
+    );
+    await expect
+      .element(page.getByRole('button', { name: 'シェア済み' }))
+      .toBeInTheDocument();
   });
 
   it('shows an error message when clipboard copy fails', async () => {


### PR DESCRIPTION
記事シェア時のタイトルからブログ名を削除しました。また、モバイル環境でのフォールバック時にはURLのみをコピーするように変更し、Web Share API使用時にはtext属性を含めるようにしました。

- タイトル構成の簡素化（ブログ名の削除）
- Web Share APIへのtext属性の追加
- モバイル環境のクリップボードコピー内容をURLのみに変更