### PR TITLE
Enhance code block rendering with Shiki syntax highlighting and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 My blog, base on [Urara](https://urara-demo.netlify.app/).
 
+## code block metadata
+
+ブログ記事の fenced code block では、先頭の info string でファイル名を指定できます。
+
+1. `filename=` 形式
+
+   ````md
+   ```ts filename=main.ts
+   const answer = 42;
+   ```
+   ````
+
+2. `lang:filename` 形式
+
+   ````md
+   ```ts:main.ts
+   const answer = 42;
+   ```
+   ````
+
+表示ルール:
+
+- ファイル名を指定した場合: `main.ts` のように**拡張子込みのファイル名**を1つのラベルで表示
+- ファイル名を指定しない場合: `ts` のように**拡張子のみ**を表示（先頭の `.` は表示しない）
+
 ## TODO
 
 - [ ] Zenn の記事も一覧に表示

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "playwright": "1.59.1",
     "satori": "0.26.0",
     "satori-html": "0.3.2",
+    "shiki": "4.0.2",
     "simple-icons": "16.17.0",
     "svelte": "5.55.4",
     "svelte-check": "4.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       satori-html:
         specifier: 0.3.2
         version: 0.3.2
+      shiki:
+        specifier: 4.0.2
+        version: 4.0.2
       simple-icons:
         specifier: 16.17.0
         version: 16.17.0
@@ -802,6 +805,37 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.16':
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
 
+  '@shikijs/core@4.0.2':
+    resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.0.2':
+    resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.0.2':
+    resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@shuding/opentype.js@1.4.0-beta.0':
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
     engines: {node: '>= 8.0.0'}
@@ -930,6 +964,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
@@ -954,9 +991,15 @@ packages:
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@typescript-eslint/types@8.58.0':
     resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitest/browser-playwright@4.1.5':
     resolution: {integrity: sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==}
@@ -1104,6 +1147,9 @@ packages:
   ccount@1.1.0:
     resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1111,6 +1157,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
   character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
@@ -1147,6 +1196,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -1471,6 +1523,12 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hex-rgb@4.3.0:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
@@ -1488,6 +1546,9 @@ packages:
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1789,6 +1850,9 @@ packages:
   mdast-util-gfm@0.1.2:
     resolution: {integrity: sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   mdast-util-to-markdown@0.6.5:
     resolution: {integrity: sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==}
 
@@ -1988,6 +2052,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2085,6 +2155,9 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2126,6 +2199,15 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   regexparam@3.0.0:
     resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
@@ -2212,6 +2294,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -2259,6 +2345,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -2291,6 +2380,9 @@ packages:
 
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2365,6 +2457,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   trough@1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
 
@@ -2421,14 +2516,29 @@ packages:
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
   unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
   unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
 
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
   unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -2444,8 +2554,14 @@ packages:
   vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
 
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
   vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.9:
     resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
@@ -2627,6 +2743,9 @@ packages:
 
   zwitch@1.0.5:
     resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3115,6 +3234,46 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
+  '@shikijs/core@4.0.2':
+    dependencies:
+      '@shikijs/primitive': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/primitive@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+
+  '@shikijs/types@4.0.2':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@shuding/opentype.js@1.4.0-beta.0':
     dependencies:
       fflate: 0.7.4
@@ -3315,6 +3474,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/katex@0.16.8': {}
 
   '@types/mdast@3.0.15':
@@ -3337,7 +3500,11 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
+  '@types/unist@3.0.3': {}
+
   '@typescript-eslint/types@8.58.0': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitest/browser-playwright@4.1.5(playwright@1.59.1)(vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3))(vitest@4.1.5)':
     dependencies:
@@ -3504,12 +3671,16 @@ snapshots:
 
   ccount@1.1.0: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
 
   character-entities-legacy@1.1.4: {}
 
@@ -3536,6 +3707,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@8.3.0: {}
 
@@ -3866,6 +4039,24 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hex-rgb@4.3.0: {}
 
   hono@4.12.14: {}
@@ -3877,6 +4068,8 @@ snapshots:
   hosted-git-info@7.0.2:
     dependencies:
       lru-cache: 10.4.3
+
+  html-void-elements@3.0.0: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4171,6 +4364,18 @@ snapshots:
       mdast-util-to-markdown: 0.6.5
     transitivePeerDependencies:
       - supports-color
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
 
   mdast-util-to-markdown@0.6.5:
     dependencies:
@@ -4488,6 +4693,14 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -4582,6 +4795,8 @@ snapshots:
 
   prismjs@1.30.0: {}
 
+  property-information@7.1.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4632,6 +4847,16 @@ snapshots:
       unicorn-magic: 0.1.0
 
   readdirp@4.1.2: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   regexparam@3.0.0: {}
 
@@ -4793,6 +5018,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@4.0.2:
+    dependencies:
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -4845,6 +5081,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -4877,6 +5115,11 @@ snapshots:
       strip-ansi: 7.2.0
 
   string.prototype.codepointat@0.2.1: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4988,6 +5231,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  trim-lines@3.0.1: {}
+
   trough@1.0.5: {}
 
   tslib@2.8.1:
@@ -5040,20 +5285,43 @@ snapshots:
 
   unist-util-is@4.1.0: {}
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
   unist-util-stringify-position@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
 
   unist-util-visit-parents@3.1.1:
     dependencies:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
 
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
   unist-util-visit@2.0.3:
     dependencies:
       '@types/unist': 2.0.11
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unpipe@1.0.0: {}
 
@@ -5069,12 +5337,22 @@ snapshots:
       '@types/unist': 2.0.11
       unist-util-stringify-position: 2.0.3
 
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
   vfile@4.2.1:
     dependencies:
       '@types/unist': 2.0.11
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.9(@types/node@25.6.0)(esbuild@0.27.3):
     dependencies:
@@ -5196,3 +5474,5 @@ snapshots:
   zod@3.25.76: {}
 
   zwitch@1.0.5: {}
+
+  zwitch@2.0.4: {}

--- a/src/lib/markdown.spec.ts
+++ b/src/lib/markdown.spec.ts
@@ -9,7 +9,6 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<div class="code-block">');
     expect(html).toContain('<span class="code-block__file">ts</span>');
     expect(html).toContain('class="code-block__copy"');
-    expect(html).toContain('data-code="const%20answer%20%3D%2042%3B"');
     expect(html).toContain('<pre class="shiki');
     expect(html).toContain('<code>');
     expect(html).toContain('<span');
@@ -31,7 +30,15 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<span class="code-block__file">main.ts</span>');
   });
 
-  it('falls back to plain-text highlighting when language is not specified', async () => {
+  it('parses filename metadata even when info string starts with filename=', async () => {
+    const html = await renderMarkdown(
+      '```filename=main.ts\nconst answer = 42;\n```'
+    );
+
+    expect(html).toContain('<span class="code-block__file">main.ts</span>');
+  });
+
+  it('falls back to markdown highlighting when language is not specified', async () => {
     const html = await renderMarkdown('```\nhello();\n```');
 
     expect(html).toContain('<pre class="shiki');

--- a/src/lib/markdown.spec.ts
+++ b/src/lib/markdown.spec.ts
@@ -9,6 +9,8 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<div class="code-block">');
     expect(html).toContain('<span class="code-block__filename">snippet</span>');
     expect(html).toContain('<span class="code-block__extension">.ts</span>');
+    expect(html).toContain('class="code-block__copy"');
+    expect(html).toContain('data-code="const%20answer%20%3D%2042%3B"');
     expect(html).toContain('<pre class="shiki');
     expect(html).toContain('<code>');
     expect(html).toContain('<span');

--- a/src/lib/markdown.spec.ts
+++ b/src/lib/markdown.spec.ts
@@ -8,6 +8,7 @@ describe('renderMarkdown', () => {
 
     expect(html).toContain('<div class="code-block">');
     expect(html).toContain('<span class="code-block__filename">snippet</span>');
+    expect(html).toContain('<span class="code-block__extension">.ts</span>');
     expect(html).toContain('<pre class="shiki');
     expect(html).toContain('<code>');
     expect(html).toContain('<span');
@@ -18,9 +19,8 @@ describe('renderMarkdown', () => {
       '```ts filename=main.ts\nconst answer = 42;\n```'
     );
 
-    expect(html).toContain(
-      '<span class="code-block__filename">main.ts</span>'
-    );
+    expect(html).toContain('<span class="code-block__filename">main</span>');
+    expect(html).toContain('<span class="code-block__extension">.ts</span>');
   });
 
   it('falls back to plain-text highlighting when language is not specified', async () => {

--- a/src/lib/markdown.spec.ts
+++ b/src/lib/markdown.spec.ts
@@ -3,12 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { renderMarkdown } from './markdown';
 
 describe('renderMarkdown', () => {
-  it('renders a fenced code block with shiki classes when language is specified', async () => {
+  it('shows extension only when filename metadata is not specified', async () => {
     const html = await renderMarkdown('```ts\nconst answer = 42;\n```');
 
     expect(html).toContain('<div class="code-block">');
-    expect(html).toContain('<span class="code-block__filename">snippet</span>');
-    expect(html).toContain('<span class="code-block__extension">.ts</span>');
+    expect(html).toContain('<span class="code-block__file">ts</span>');
     expect(html).toContain('class="code-block__copy"');
     expect(html).toContain('data-code="const%20answer%20%3D%2042%3B"');
     expect(html).toContain('<pre class="shiki');
@@ -16,13 +15,20 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<span');
   });
 
-  it('renders filename metadata in the code block header', async () => {
+  it('shows filename and extension together when filename metadata is specified', async () => {
     const html = await renderMarkdown(
       '```ts filename=main.ts\nconst answer = 42;\n```'
     );
 
-    expect(html).toContain('<span class="code-block__filename">main</span>');
-    expect(html).toContain('<span class="code-block__extension">.ts</span>');
+    expect(html).toContain('<span class="code-block__file">main.ts</span>');
+  });
+
+  it('appends extension from language when filename has no extension', async () => {
+    const html = await renderMarkdown(
+      '```ts filename=main\nconst answer = 42;\n```'
+    );
+
+    expect(html).toContain('<span class="code-block__file">main.ts</span>');
   });
 
   it('falls back to plain-text highlighting when language is not specified', async () => {

--- a/src/lib/markdown.spec.ts
+++ b/src/lib/markdown.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown', () => {
+  it('renders a fenced code block with shiki classes when language is specified', async () => {
+    const html = await renderMarkdown('```ts\nconst answer = 42;\n```');
+
+    expect(html).toContain('<pre class="shiki');
+    expect(html).toContain('<code>');
+    expect(html).toContain('<span');
+  });
+
+  it('falls back to plain-text highlighting when language is not specified', async () => {
+    const html = await renderMarkdown('```\nhello();\n```');
+
+    expect(html).toContain('<pre class="shiki');
+    expect(html).toContain('hello');
+  });
+});

--- a/src/lib/markdown.spec.ts
+++ b/src/lib/markdown.spec.ts
@@ -6,9 +6,21 @@ describe('renderMarkdown', () => {
   it('renders a fenced code block with shiki classes when language is specified', async () => {
     const html = await renderMarkdown('```ts\nconst answer = 42;\n```');
 
+    expect(html).toContain('<div class="code-block">');
+    expect(html).toContain('<span class="code-block__filename">snippet</span>');
     expect(html).toContain('<pre class="shiki');
     expect(html).toContain('<code>');
     expect(html).toContain('<span');
+  });
+
+  it('renders filename metadata in the code block header', async () => {
+    const html = await renderMarkdown(
+      '```ts filename=main.ts\nconst answer = 42;\n```'
+    );
+
+    expect(html).toContain(
+      '<span class="code-block__filename">main.ts</span>'
+    );
   });
 
   it('falls back to plain-text highlighting when language is not specified', async () => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -11,6 +11,24 @@ type HighlightedHtmlToken = {
 };
 
 const DEFAULT_FILENAME = 'snippet';
+const DEFAULT_EXTENSION = '.md';
+const EXTENSION_BY_LANGUAGE: Record<string, string> = {
+  bash: 'sh',
+  csharp: 'cs',
+  javascript: 'js',
+  js: 'js',
+  json: 'json',
+  jsx: 'jsx',
+  markdown: 'md',
+  md: 'md',
+  shell: 'sh',
+  shellscript: 'sh',
+  ts: 'ts',
+  tsx: 'tsx',
+  typescript: 'ts',
+  yaml: 'yml',
+  yml: 'yml',
+};
 
 type CodeFenceMeta = {
   language?: string;
@@ -73,14 +91,58 @@ function escapeHtml(value: string): string {
     .replaceAll("'", '&#39;');
 }
 
+function extractExtension(filename: string): string | undefined {
+  const dotIndex = filename.lastIndexOf('.');
+  if (dotIndex <= 0 || dotIndex === filename.length - 1) {
+    return undefined;
+  }
+
+  const extension = filename.slice(dotIndex + 1).toLowerCase();
+  return extension.length > 0 ? extension : undefined;
+}
+
+function extractFilenameLabel(filename: string): string {
+  const dotIndex = filename.lastIndexOf('.');
+  if (dotIndex <= 0) {
+    return filename;
+  }
+
+  return filename.slice(0, dotIndex);
+}
+
+function resolveExtension(filename: string, language?: string): string {
+  const fromFilename = extractExtension(filename);
+  if (fromFilename) {
+    return `.${fromFilename}`;
+  }
+
+  const normalizedLanguage = language?.trim().toLowerCase();
+  if (normalizedLanguage) {
+    const mappedExtension = EXTENSION_BY_LANGUAGE[normalizedLanguage];
+    if (mappedExtension) {
+      return `.${mappedExtension}`;
+    }
+
+    const sanitizedLanguage = normalizedLanguage.replace(/[^a-z0-9]+/g, '');
+    if (sanitizedLanguage.length > 0) {
+      return `.${sanitizedLanguage}`;
+    }
+  }
+
+  return DEFAULT_EXTENSION;
+}
+
 async function renderCodeBlock(code: string, rawInfo?: string): Promise<string> {
   const meta = parseCodeFenceMeta(rawInfo);
   const highlighted = await highlightCodeBlock(code, meta.language);
+  const filenameLabel = extractFilenameLabel(meta.filename);
+  const extensionLabel = resolveExtension(meta.filename, meta.language);
 
   return `
 <div class="code-block">
   <div class="code-block__header">
-    <span class="code-block__filename">${escapeHtml(meta.filename)}</span>
+    <span class="code-block__filename">${escapeHtml(filenameLabel)}</span>
+    <span class="code-block__extension">${escapeHtml(extensionLabel)}</span>
   </div>
   ${highlighted}
 </div>`.trim();

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -10,6 +10,82 @@ type HighlightedHtmlToken = {
   block: boolean;
 };
 
+const DEFAULT_FILENAME = 'snippet';
+
+type CodeFenceMeta = {
+  language?: string;
+  filename: string;
+};
+
+function unquote(value: string): string {
+  return value.replace(/^['"](.*)['"]$/, '$1');
+}
+
+function sanitizeFilename(value?: string): string {
+  const normalized = value?.split(/[/\\]/).at(-1)?.trim();
+  return normalized && normalized.length > 0 ? normalized : DEFAULT_FILENAME;
+}
+
+function parseCodeFenceMeta(rawInfo?: string): CodeFenceMeta {
+  const info = rawInfo?.trim();
+  if (!info) {
+    return { filename: DEFAULT_FILENAME };
+  }
+
+  const [head, ...rest] = info.split(/\s+/).filter((token) => token.length > 0);
+  if (!head) {
+    return { filename: DEFAULT_FILENAME };
+  }
+
+  let language: string | undefined = head;
+  let filename: string | undefined;
+
+  const headSplitIndex = head.indexOf(':');
+  if (headSplitIndex > 0) {
+    language = head.slice(0, headSplitIndex);
+    filename = head.slice(headSplitIndex + 1);
+  }
+
+  for (const token of rest) {
+    const keyValueMatch = token.match(/^(?:file|filename|name|title)=(.+)$/i);
+    if (keyValueMatch) {
+      filename = unquote(keyValueMatch[1]);
+      continue;
+    }
+
+    if (!filename && token.includes('.') && !token.startsWith('{')) {
+      filename = token;
+    }
+  }
+
+  return {
+    language: language?.trim(),
+    filename: sanitizeFilename(filename),
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+async function renderCodeBlock(code: string, rawInfo?: string): Promise<string> {
+  const meta = parseCodeFenceMeta(rawInfo);
+  const highlighted = await highlightCodeBlock(code, meta.language);
+
+  return `
+<div class="code-block">
+  <div class="code-block__header">
+    <span class="code-block__filename">${escapeHtml(meta.filename)}</span>
+  </div>
+  ${highlighted}
+</div>`.trim();
+}
+
 export async function renderMarkdown(markdown: string): Promise<string> {
   const tokens = marked.lexer(markdown);
 
@@ -19,7 +95,7 @@ export async function renderMarkdown(markdown: string): Promise<string> {
         return;
       }
 
-      const highlighted = await highlightCodeBlock(token.text, token.lang);
+      const highlighted = await renderCodeBlock(token.text, token.lang);
       const htmlToken = token as unknown as HighlightedHtmlToken;
 
       htmlToken.type = 'html';

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,34 @@
+import { marked } from 'marked';
+
+import { highlightCodeBlock } from './syntax-highlight';
+
+type HighlightedHtmlToken = {
+  type: 'html';
+  raw: string;
+  text: string;
+  pre: boolean;
+  block: boolean;
+};
+
+export async function renderMarkdown(markdown: string): Promise<string> {
+  const tokens = marked.lexer(markdown);
+
+  await Promise.all(
+    marked.walkTokens(tokens, async (token) => {
+      if (token.type !== 'code') {
+        return;
+      }
+
+      const highlighted = await highlightCodeBlock(token.text, token.lang);
+      const htmlToken = token as unknown as HighlightedHtmlToken;
+
+      htmlToken.type = 'html';
+      htmlToken.raw = highlighted;
+      htmlToken.text = highlighted;
+      htmlToken.pre = true;
+      htmlToken.block = true;
+    })
+  );
+
+  return marked.parser(tokens).trim();
+}

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -10,8 +10,7 @@ type HighlightedHtmlToken = {
   block: boolean;
 };
 
-const DEFAULT_FILENAME = 'snippet';
-const DEFAULT_EXTENSION = '.md';
+const DEFAULT_EXTENSION = 'md';
 const EXTENSION_BY_LANGUAGE: Record<string, string> = {
   bash: 'sh',
   csharp: 'cs',
@@ -32,27 +31,27 @@ const EXTENSION_BY_LANGUAGE: Record<string, string> = {
 
 type CodeFenceMeta = {
   language?: string;
-  filename: string;
+  filename?: string;
 };
 
 function unquote(value: string): string {
   return value.replace(/^['"](.*)['"]$/, '$1');
 }
 
-function sanitizeFilename(value?: string): string {
+function sanitizeFilename(value?: string): string | undefined {
   const normalized = value?.split(/[/\\]/).at(-1)?.trim();
-  return normalized && normalized.length > 0 ? normalized : DEFAULT_FILENAME;
+  return normalized && normalized.length > 0 ? normalized : undefined;
 }
 
 function parseCodeFenceMeta(rawInfo?: string): CodeFenceMeta {
   const info = rawInfo?.trim();
   if (!info) {
-    return { filename: DEFAULT_FILENAME };
+    return {};
   }
 
   const [head, ...rest] = info.split(/\s+/).filter((token) => token.length > 0);
   if (!head) {
-    return { filename: DEFAULT_FILENAME };
+    return {};
   }
 
   let language: string | undefined = head;
@@ -91,7 +90,11 @@ function escapeHtml(value: string): string {
     .replaceAll("'", '&#39;');
 }
 
-function extractExtension(filename: string): string | undefined {
+function extractExtension(filename?: string): string | undefined {
+  if (!filename) {
+    return undefined;
+  }
+
   const dotIndex = filename.lastIndexOf('.');
   if (dotIndex <= 0 || dotIndex === filename.length - 1) {
     return undefined;
@@ -101,49 +104,51 @@ function extractExtension(filename: string): string | undefined {
   return extension.length > 0 ? extension : undefined;
 }
 
-function extractFilenameLabel(filename: string): string {
-  const dotIndex = filename.lastIndexOf('.');
-  if (dotIndex <= 0) {
-    return filename;
-  }
-
-  return filename.slice(0, dotIndex);
-}
-
-function resolveExtension(filename: string, language?: string): string {
+function resolveExtension(filename?: string, language?: string): string {
   const fromFilename = extractExtension(filename);
   if (fromFilename) {
-    return `.${fromFilename}`;
+    return fromFilename;
   }
 
   const normalizedLanguage = language?.trim().toLowerCase();
   if (normalizedLanguage) {
     const mappedExtension = EXTENSION_BY_LANGUAGE[normalizedLanguage];
     if (mappedExtension) {
-      return `.${mappedExtension}`;
+      return mappedExtension;
     }
 
     const sanitizedLanguage = normalizedLanguage.replace(/[^a-z0-9]+/g, '');
     if (sanitizedLanguage.length > 0) {
-      return `.${sanitizedLanguage}`;
+      return sanitizedLanguage;
     }
   }
 
   return DEFAULT_EXTENSION;
 }
 
+function resolveFileLabel(meta: CodeFenceMeta): string {
+  if (!meta.filename) {
+    return resolveExtension(undefined, meta.language);
+  }
+
+  const existingExtension = extractExtension(meta.filename);
+  if (existingExtension) {
+    return meta.filename;
+  }
+
+  return `${meta.filename}.${resolveExtension(undefined, meta.language)}`;
+}
+
 async function renderCodeBlock(code: string, rawInfo?: string): Promise<string> {
   const meta = parseCodeFenceMeta(rawInfo);
   const highlighted = await highlightCodeBlock(code, meta.language);
-  const filenameLabel = extractFilenameLabel(meta.filename);
-  const extensionLabel = resolveExtension(meta.filename, meta.language);
+  const fileLabel = resolveFileLabel(meta);
   const encodedCode = encodeURIComponent(code);
 
   return `
 <div class="code-block">
   <div class="code-block__header">
-    <span class="code-block__filename">${escapeHtml(filenameLabel)}</span>
-    <span class="code-block__extension">${escapeHtml(extensionLabel)}</span>
+    <span class="code-block__file">${escapeHtml(fileLabel)}</span>
     <button
       type="button"
       class="code-block__copy"

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -137,12 +137,20 @@ async function renderCodeBlock(code: string, rawInfo?: string): Promise<string> 
   const highlighted = await highlightCodeBlock(code, meta.language);
   const filenameLabel = extractFilenameLabel(meta.filename);
   const extensionLabel = resolveExtension(meta.filename, meta.language);
+  const encodedCode = encodeURIComponent(code);
 
   return `
 <div class="code-block">
   <div class="code-block__header">
     <span class="code-block__filename">${escapeHtml(filenameLabel)}</span>
     <span class="code-block__extension">${escapeHtml(extensionLabel)}</span>
+    <button
+      type="button"
+      class="code-block__copy"
+      data-code-copy
+      data-code="${escapeHtml(encodedCode)}"
+      aria-label="copy code"
+    >copy</button>
   </div>
   ${highlighted}
 </div>`.trim();

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -54,13 +54,20 @@ function parseCodeFenceMeta(rawInfo?: string): CodeFenceMeta {
     return {};
   }
 
-  let language: string | undefined = head;
+  let language: string | undefined;
   let filename: string | undefined;
 
-  const headSplitIndex = head.indexOf(':');
-  if (headSplitIndex > 0) {
-    language = head.slice(0, headSplitIndex);
-    filename = head.slice(headSplitIndex + 1);
+  const headKeyValueMatch = head.match(/^(?:file|filename|name|title)=(.+)$/i);
+  if (headKeyValueMatch) {
+    filename = unquote(headKeyValueMatch[1]);
+  } else {
+    const headSplitIndex = head.indexOf(':');
+    if (headSplitIndex > 0) {
+      language = head.slice(0, headSplitIndex);
+      filename = head.slice(headSplitIndex + 1);
+    } else {
+      language = head;
+    }
   }
 
   for (const token of rest) {
@@ -143,7 +150,6 @@ async function renderCodeBlock(code: string, rawInfo?: string): Promise<string> 
   const meta = parseCodeFenceMeta(rawInfo);
   const highlighted = await highlightCodeBlock(code, meta.language);
   const fileLabel = resolveFileLabel(meta);
-  const encodedCode = encodeURIComponent(code);
 
   return `
 <div class="code-block">
@@ -153,7 +159,6 @@ async function renderCodeBlock(code: string, rawInfo?: string): Promise<string> 
       type="button"
       class="code-block__copy"
       data-code-copy
-      data-code="${escapeHtml(encodedCode)}"
       aria-label="copy code"
     >copy</button>
   </div>

--- a/src/lib/posts.spec.ts
+++ b/src/lib/posts.spec.ts
@@ -17,6 +17,13 @@ describe('posts', () => {
     expect(post?.content).toContain('<h2>感想</h2>');
   });
 
+  it('renders fenced code blocks in posts with highlighted html', async () => {
+    const post = await getPost('sara-arai');
+
+    expect(post).not.toBeNull();
+    expect(post?.content).toContain('<pre class="shiki');
+  });
+
   it('returns posts sorted by created date descending', async () => {
     const posts = await getAllPosts({ includeUnlisted: true });
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,5 +1,3 @@
-import { marked } from 'marked';
-
 import {
   comparePostsByCreatedDesc,
   createExcerpt,
@@ -7,6 +5,7 @@ import {
   parseFrontmatter,
   splitFrontmatter,
 } from './post-parser';
+import { renderMarkdown } from './markdown';
 
 type RawPostModule = Record<string, string>;
 import type { PostTag, ParsedFrontmatter } from './post-parser';
@@ -109,7 +108,7 @@ async function loadPosts(): Promise<Post[]> {
 
       const { frontmatter, markdown } = splitFrontmatter(source);
       const metadata = parseFrontmatter(frontmatter);
-      const content = await renderMarkdown(markdown, slug);
+      const content = await renderMarkdown(markdown);
 
       return {
         slug,
@@ -127,14 +126,6 @@ async function loadPosts(): Promise<Post[]> {
   ).then((posts) => posts.sort(comparePostsByCreatedDesc));
 
   return postsPromise;
-}
-
-async function renderMarkdown(markdown: string, slug: string): Promise<string> {
-  const rendered = await marked.parse(markdown, {
-    async: true,
-  });
-
-  return rendered.trim();
 }
 
 function filterPosts(posts: Post[], options: GetPostsOptions): Post[] {

--- a/src/lib/syntax-highlight.ts
+++ b/src/lib/syntax-highlight.ts
@@ -1,0 +1,70 @@
+import {
+  bundledLanguages,
+  getSingletonHighlighter,
+  type BundledLanguage,
+  type BundledTheme,
+} from 'shiki';
+
+const SHIKI_THEME: BundledTheme = 'github-light';
+const PLAIN_TEXT_ALIASES = new Set(['plain', 'plaintext', 'text', 'txt']);
+const FALLBACK_LANGUAGE: BundledLanguage = 'md';
+
+const loadedLanguages = new Set<BundledLanguage>([FALLBACK_LANGUAGE]);
+
+type ShikiHighlighter = Awaited<ReturnType<typeof getSingletonHighlighter>>;
+
+let highlighterPromise: Promise<ShikiHighlighter> | undefined;
+
+function parseLanguage(rawLanguage?: string): BundledLanguage {
+  const candidate = rawLanguage
+    ?.trim()
+    .split(/\s+/)[0]
+    ?.replace(/\{.*\}$/, '')
+    .toLowerCase();
+
+  if (!candidate || PLAIN_TEXT_ALIASES.has(candidate)) {
+    return FALLBACK_LANGUAGE;
+  }
+
+  if (candidate in bundledLanguages) {
+    return candidate as BundledLanguage;
+  }
+
+  return FALLBACK_LANGUAGE;
+}
+
+async function getHighlighter(): Promise<ShikiHighlighter> {
+  highlighterPromise ??= getSingletonHighlighter({
+    themes: [SHIKI_THEME],
+    langs: [FALLBACK_LANGUAGE],
+  });
+
+  return highlighterPromise;
+}
+
+async function ensureLanguageLoaded(
+  highlighter: ShikiHighlighter,
+  language: BundledLanguage
+): Promise<void> {
+  if (loadedLanguages.has(language)) {
+    return;
+  }
+
+  await highlighter.loadLanguage(language);
+  loadedLanguages.add(language);
+}
+
+export async function highlightCodeBlock(
+  code: string,
+  rawLanguage?: string
+): Promise<string> {
+  const language = parseLanguage(rawLanguage);
+  const highlighter = await getHighlighter();
+
+  await ensureLanguageLoaded(highlighter, language);
+
+  return highlighter.codeToHtml(code, {
+    lang: language,
+    theme: SHIKI_THEME,
+  });
+}

--- a/src/lib/syntax-highlight.ts
+++ b/src/lib/syntax-highlight.ts
@@ -10,6 +10,7 @@ const PLAIN_TEXT_ALIASES = new Set(['plain', 'plaintext', 'text', 'txt']);
 const FALLBACK_LANGUAGE: BundledLanguage = 'md';
 
 const loadedLanguages = new Set<BundledLanguage>([FALLBACK_LANGUAGE]);
+const loadingLanguages = new Map<BundledLanguage, Promise<void>>();
 
 type ShikiHighlighter = Awaited<ReturnType<typeof getSingletonHighlighter>>;
 
@@ -50,8 +51,23 @@ async function ensureLanguageLoaded(
     return;
   }
 
-  await highlighter.loadLanguage(language);
-  loadedLanguages.add(language);
+  const inFlightLoading = loadingLanguages.get(language);
+  if (inFlightLoading) {
+    await inFlightLoading;
+    return;
+  }
+
+  const loading = highlighter
+    .loadLanguage(language)
+    .then(() => {
+      loadedLanguages.add(language);
+    })
+    .finally(() => {
+      loadingLanguages.delete(language);
+    });
+
+  loadingLanguages.set(language, loading);
+  await loading;
 }
 
 export async function highlightCodeBlock(

--- a/src/lib/syntax-highlight.ts
+++ b/src/lib/syntax-highlight.ts
@@ -1,5 +1,6 @@
 import {
   bundledLanguages,
+  createJavaScriptRegexEngine,
   getSingletonHighlighter,
   type BundledLanguage,
   type BundledTheme,
@@ -36,6 +37,7 @@ function parseLanguage(rawLanguage?: string): BundledLanguage {
 
 async function getHighlighter(): Promise<ShikiHighlighter> {
   highlighterPromise ??= getSingletonHighlighter({
+    engine: createJavaScriptRegexEngine(),
     themes: [SHIKI_THEME],
     langs: [FALLBACK_LANGUAGE],
   });

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -256,7 +256,11 @@
   .article-content :global(pre) {
     margin: 1.5rem 0;
     padding: 1rem;
+    border: 1px solid #cbd5e1;
     border-radius: 0.75rem;
+    box-shadow:
+      0 1px 2px rgb(15 23 42 / 0.08),
+      inset 0 0 0 1px rgb(255 255 255 / 0.65);
     overflow-x: auto;
   }
 

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -112,12 +112,15 @@
     codeCopyResetTimers.set(button, timer);
   }
 
-  function decodeCodePayload(payload: string): string | null {
-    try {
-      return decodeURIComponent(payload);
-    } catch {
+  function getCodeTextFromBlock(button: HTMLButtonElement): string | null {
+    const container = button.closest('.code-block');
+    if (!container) {
       return null;
     }
+
+    const codeElement = container.querySelector('pre code');
+    const codeText = codeElement?.textContent;
+    return codeText ?? null;
   }
 
   async function copyCodeFromButton(button: HTMLButtonElement) {
@@ -127,22 +130,15 @@
       return;
     }
 
-    const encoded = button.getAttribute('data-code');
-    if (!encoded) {
-      setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
-      scheduleCodeCopyButtonReset(button);
-      return;
-    }
-
-    const code = decodeCodePayload(encoded);
-    if (code === null) {
+    const codeText = getCodeTextFromBlock(button);
+    if (codeText === null) {
       setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
       scheduleCodeCopyButtonReset(button);
       return;
     }
 
     try {
-      await navigator.clipboard.writeText(code);
+      await navigator.clipboard.writeText(codeText);
       setCodeCopyButtonLabel(button, CODE_COPY_SUCCESS_LABEL);
     } catch {
       setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
@@ -180,6 +176,7 @@
       for (const timer of codeCopyResetTimers.values()) {
         window.clearTimeout(timer);
       }
+      codeCopyResetTimers.clear();
     };
   });
 </script>
@@ -366,7 +363,7 @@
   .article-content :global(.code-block__header) {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
+    gap: 0.55rem;
     min-height: 2.25rem;
     padding: 0.35rem 0.75rem;
     border-bottom: 1px solid #cbd5e1;
@@ -390,7 +387,6 @@
   }
 
   .article-content :global(.code-block__copy) {
-    margin-left: auto;
     border: 1px solid #cbd5e1;
     border-radius: 0.45rem;
     background: #fff;

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { getArticleOgpImageUrl } from '$lib/ogp';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
   type ShareState = 'idle' | 'success' | 'error';
+  const CODE_COPY_SELECTOR = '[data-code-copy]';
+  const CODE_COPY_DEFAULT_LABEL = 'copy';
+  const CODE_COPY_SUCCESS_LABEL = 'copied';
+  const CODE_COPY_ERROR_LABEL = 'error';
+  const CODE_COPY_RESET_DELAY_MS = 1500;
 
   let shareState = $state<ShareState>('idle');
+  let articleContentElement = $state<HTMLElement | null>(null);
+  const codeCopyResetTimers = new Map<HTMLButtonElement, number>();
 
   function getShareUrl() {
     return new URL(`/articles/${data.post.slug}`, data.origin).toString();
@@ -84,6 +92,96 @@
 
     await copyShareText(getShareUrl());
   }
+
+  function setCodeCopyButtonLabel(button: HTMLButtonElement, label: string) {
+    button.textContent = label;
+    button.setAttribute('aria-label', label);
+  }
+
+  function scheduleCodeCopyButtonReset(button: HTMLButtonElement) {
+    const existingTimer = codeCopyResetTimers.get(button);
+    if (existingTimer !== undefined) {
+      window.clearTimeout(existingTimer);
+    }
+
+    const timer = window.setTimeout(() => {
+      setCodeCopyButtonLabel(button, CODE_COPY_DEFAULT_LABEL);
+      codeCopyResetTimers.delete(button);
+    }, CODE_COPY_RESET_DELAY_MS);
+
+    codeCopyResetTimers.set(button, timer);
+  }
+
+  function decodeCodePayload(payload: string): string | null {
+    try {
+      return decodeURIComponent(payload);
+    } catch {
+      return null;
+    }
+  }
+
+  async function copyCodeFromButton(button: HTMLButtonElement) {
+    if (typeof navigator === 'undefined' || !('clipboard' in navigator)) {
+      setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
+      scheduleCodeCopyButtonReset(button);
+      return;
+    }
+
+    const encoded = button.getAttribute('data-code');
+    if (!encoded) {
+      setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
+      scheduleCodeCopyButtonReset(button);
+      return;
+    }
+
+    const code = decodeCodePayload(encoded);
+    if (code === null) {
+      setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
+      scheduleCodeCopyButtonReset(button);
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(code);
+      setCodeCopyButtonLabel(button, CODE_COPY_SUCCESS_LABEL);
+    } catch {
+      setCodeCopyButtonLabel(button, CODE_COPY_ERROR_LABEL);
+    }
+
+    scheduleCodeCopyButtonReset(button);
+  }
+
+  onMount(() => {
+    if (!articleContentElement) {
+      return;
+    }
+
+    const handleArticleContentClick = async (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      const copyButton = target.closest(CODE_COPY_SELECTOR);
+      if (!(copyButton instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      await copyCodeFromButton(copyButton);
+    };
+
+    articleContentElement.addEventListener('click', handleArticleContentClick);
+
+    return () => {
+      articleContentElement?.removeEventListener(
+        'click',
+        handleArticleContentClick
+      );
+      for (const timer of codeCopyResetTimers.values()) {
+        window.clearTimeout(timer);
+      }
+    };
+  });
 </script>
 
 <svelte:head>
@@ -128,7 +226,9 @@
     <img class="article-image" src={data.post.image} alt="">
   {/if}
 
-  <div class="article-content">{@html data.post.content}</div>
+  <div class="article-content" bind:this={articleContentElement}>
+    {@html data.post.content}
+  </div>
 
   <footer class="article-footer">
     <button
@@ -296,6 +396,29 @@
       "Courier New", monospace;
     font-size: 0.72rem;
     font-weight: 700;
+  }
+
+  .article-content :global(.code-block__copy) {
+    margin-left: auto;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.45rem;
+    background: #fff;
+    color: #1e293b;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    text-transform: lowercase;
+    padding: 0.35rem 0.45rem;
+    cursor: pointer;
+  }
+
+  .article-content :global(.code-block__copy:hover) {
+    background: #f1f5f9;
+  }
+
+  .article-content :global(.code-block__copy:focus-visible) {
+    outline: 2px solid #f59e0b;
+    outline-offset: 2px;
   }
 
   .article-content :global(pre) {

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -253,6 +253,27 @@
     border-bottom-color: #db2777;
   }
 
+  .article-content :global(pre) {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    border-radius: 0.75rem;
+    overflow-x: auto;
+  }
+
+  .article-content :global(pre code) {
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 0.9rem;
+    line-height: 1.7;
+  }
+
+  .article-content :global(:not(pre) > code) {
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.375rem;
+    background: #e2e8f0;
+  }
+
   .article-content :global(p),
   .article-content :global(li) {
     line-height: 1.8;

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -373,28 +373,19 @@
     background: #f8fafc;
   }
 
-  .article-content :global(.code-block__filename) {
-    font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-      "Courier New", monospace;
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: #334155;
-  }
-
-  .article-content :global(.code-block__extension) {
+  .article-content :global(.code-block__file) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     min-height: 1.25rem;
     padding: 0 0.45rem;
     border-radius: 9999px;
-    background: #dbeafe;
-    color: #1e3a8a;
+    background: #e2e8f0;
+    color: #334155;
     font-family:
       ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
-    font-size: 0.72rem;
+    font-size: 0.76rem;
     font-weight: 700;
   }
 

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -253,14 +253,39 @@
     border-bottom-color: #db2777;
   }
 
-  .article-content :global(pre) {
+  .article-content :global(.code-block) {
     margin: 1.5rem 0;
-    padding: 1rem;
     border: 1px solid #cbd5e1;
     border-radius: 0.75rem;
+    overflow: hidden;
     box-shadow:
       0 1px 2px rgb(15 23 42 / 0.08),
       inset 0 0 0 1px rgb(255 255 255 / 0.65);
+  }
+
+  .article-content :global(.code-block__header) {
+    display: flex;
+    align-items: center;
+    min-height: 2.25rem;
+    padding: 0.35rem 0.75rem;
+    border-bottom: 1px solid #cbd5e1;
+    background: #f8fafc;
+  }
+
+  .article-content :global(.code-block__filename) {
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 0.8rem;
+    color: #334155;
+  }
+
+  .article-content :global(pre) {
+    margin: 0;
+    padding: 1rem;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
     overflow-x: auto;
   }
 

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -352,6 +352,8 @@
 
   .article-content :global(.code-block) {
     margin: 1.5rem 0;
+    width: 100%;
+    box-sizing: border-box;
     border: 1px solid #cbd5e1;
     border-radius: 0.75rem;
     overflow: hidden;
@@ -410,11 +412,13 @@
 
   .article-content :global(pre) {
     margin: 0;
+    width: 100%;
+    box-sizing: border-box;
     padding: 1rem;
     border: 0;
     border-radius: 0;
     box-shadow: none;
-    overflow-x: auto;
+    overflow-x: visible;
   }
 
   .article-content :global(pre code) {
@@ -423,6 +427,29 @@
       "Courier New", monospace;
     font-size: 0.9rem;
     line-height: 1.7;
+    white-space: normal;
+    counter-reset: code-line;
+  }
+
+  .article-content :global(pre code .line) {
+    display: block;
+    position: relative;
+    min-height: 1.7em;
+    padding-left: 2.8rem;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .article-content :global(pre code .line::before) {
+    position: absolute;
+    left: 0;
+    width: 2.2rem;
+    text-align: right;
+    color: #94a3b8;
+    user-select: none;
+    content: counter(code-line);
+    counter-increment: code-line;
   }
 
   .article-content :global(:not(pre) > code) {

--- a/src/routes/articles/[slug]/+page.svelte
+++ b/src/routes/articles/[slug]/+page.svelte
@@ -266,6 +266,7 @@
   .article-content :global(.code-block__header) {
     display: flex;
     align-items: center;
+    gap: 0.4rem;
     min-height: 2.25rem;
     padding: 0.35rem 0.75rem;
     border-bottom: 1px solid #cbd5e1;
@@ -277,7 +278,24 @@
       ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
     font-size: 0.8rem;
+    font-weight: 600;
     color: #334155;
+  }
+
+  .article-content :global(.code-block__extension) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 1.25rem;
+    padding: 0 0.45rem;
+    border-radius: 9999px;
+    background: #dbeafe;
+    color: #1e3a8a;
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 0.72rem;
+    font-weight: 700;
   }
 
   .article-content :global(pre) {

--- a/src/routes/articles/[slug]/page.svelte.spec.ts
+++ b/src/routes/articles/[slug]/page.svelte.spec.ts
@@ -273,7 +273,6 @@ describe('/articles/[slug]/+page.svelte', () => {
                   type="button"
                   class="code-block__copy"
                   data-code-copy
-                  data-code="const%20a%20%3D%201%3B"
                   aria-label="copy code"
                 >copy</button>
               </div>

--- a/src/routes/articles/[slug]/page.svelte.spec.ts
+++ b/src/routes/articles/[slug]/page.svelte.spec.ts
@@ -268,8 +268,7 @@ describe('/articles/[slug]/+page.svelte', () => {
           content: `
             <div class="code-block">
               <div class="code-block__header">
-                <span class="code-block__filename">main</span>
-                <span class="code-block__extension">.ts</span>
+                <span class="code-block__file">main.ts</span>
                 <button
                   type="button"
                   class="code-block__copy"

--- a/src/routes/articles/[slug]/page.svelte.spec.ts
+++ b/src/routes/articles/[slug]/page.svelte.spec.ts
@@ -252,4 +252,44 @@ describe('/articles/[slug]/+page.svelte', () => {
     expect(share).not.toHaveBeenCalled();
     await expect.element(page.getByText('エラー')).toBeInTheDocument();
   });
+
+  it('copies code block content with the copy button', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(Page, {
+      data: makeArticlePageData({
+        post: makePost({
+          tags: [],
+          content: `
+            <div class="code-block">
+              <div class="code-block__header">
+                <span class="code-block__filename">main</span>
+                <span class="code-block__extension">.ts</span>
+                <button
+                  type="button"
+                  class="code-block__copy"
+                  data-code-copy
+                  data-code="const%20a%20%3D%201%3B"
+                  aria-label="copy code"
+                >copy</button>
+              </div>
+              <pre class="shiki"><code>const a = 1;</code></pre>
+            </div>
+          `,
+        }),
+      }),
+    });
+
+    await page.getByRole('button', { name: 'copy code' }).click();
+
+    expect(writeText).toHaveBeenCalledWith('const a = 1;');
+    await expect
+      .element(page.getByRole('button', { name: 'copied' }))
+      .toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
close #725 
This pull request introduces support for specifying filenames in fenced code blocks within blog posts, and adds the `shiki` library for syntax highlighting. It also updates the documentation to explain the new code block metadata feature and brings in a number of new dependencies, primarily to support enhanced code highlighting and AST processing.

Key changes:

**Feature: Code Block Metadata Support**
- Added documentation in `README.md` describing how to specify filenames in fenced code blocks using either the `filename=` or `lang:filename` format, and clarified display rules for code block labels.

**Dependency Additions: Syntax Highlighting and AST Utilities**
- Added `shiki` (v4.0.2) to `package.json` to enable advanced syntax highlighting.
- Updated `pnpm-lock.yaml` to include `shiki` and its dependencies, such as `@shikijs/core`, `@shikijs/langs`, `@shikijs/themes`, `@shikijs/engine-javascript`, `@shikijs/engine-oniguruma`, and related packages. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR60-R62) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR808-R838) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2297-R2300) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3237-R3276)
- Added several AST and utility libraries (`@types/hast`, `@types/unist`, `mdast-util-to-hast`, `unist-util-*`, `hast-util-to-html`, etc.) to support code parsing and transformation, as reflected in the lockfile. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR967-R969) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR994-R1003) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1526-R1531) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1853-R1855) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2519-R2542) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3477-R3480) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3503-R3508)

**Dependency Additions: Utility Packages**
- Added other utility packages such as `ccount`, `comma-separated-tokens`, `space-separated-tokens`, `property-information`, `trim-lines`, `stringify-entities`, and more, which are mostly indirect dependencies required by the new AST and highlighting libraries. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1150-R1152) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1200-R1202) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2158-R2160) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2348-R2350) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2460-R2462) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2557-R2565) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2747-R2749) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3674-R3684) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3711-R3712)