### PR TITLE
Fix ci test

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -18,7 +18,7 @@ jobs:
           log_level: 'debug'
       - name: Get pnpm store directory
         id: pnpm-cache-dir
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path --silent | tail -n 1)" >> $GITHUB_OUTPUT
       - name: Cache pnpm dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           install: true
       - name: Get pnpm store directory
         id: pnpm-cache-dir
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path --silent | tail -n 1)" >> $GITHUB_OUTPUT
       - name: Cache pnpm dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: playwright-cache
         with:
-          path: ~/.cache/msplaywright
+          path: ~/.cache/ms-playwright
           # Playwrightのバージョンが変わった時だけキャッシュを作り直す
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.VERSION }}
       - name: Install Playwright browsers


### PR DESCRIPTION
This pull request makes small but important improvements to the GitHub Actions workflows for formatting and testing. The main focus is on making caching more robust and accurate by refining how paths are determined and used.

Workflow improvements:

* Updated the command for determining the `pnpm` store path in both `.github/workflows/format.yaml` and `.github/workflows/test.yaml` to use `pnpm store path --silent | tail -n 1`, ensuring only the correct path is captured for caching. [[1]](diffhunk://#diff-d671e201597b1543c1a04bea8290f7427b53646c708722719872792b39760b56L21-R21) [[2]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L22-R22)
* Fixed a typo in the Playwright cache path in `.github/workflows/test.yaml`, changing it from `~/.cache/msplaywright` to `~/.cache/ms-playwright` for accuracy.